### PR TITLE
Fix typos in running-and-saving.mdx

### DIFF
--- a/docs/running-and-saving.mdx
+++ b/docs/running-and-saving.mdx
@@ -17,13 +17,13 @@ When you fork a project, the project title & description will also be copied. Yo
 
 The title & description will display to anyone viewing your project, and in meta tags when sharing your project (e.g. via URLs, social cards etc).
 
-## Limiations
+## Limitations
 
 We're aware of the current limitations, and are working on ways to resolve these (please bear with us, it's complicated!):
 
 - If the build process errors, the project code will not be saved (read; it is currently not possible to save code that cannot compile).
 - Saving & Building are tied to the same process - you cannot save code without building.
 - Build speed depends upon your local machine specs. We're working hard to improve compilation speeds.
-  - On Apple Sillicon chips, compilation on average takes between 900-1200ms on first runs. Subsequest runs are much faster (~200ms).
-  - On Intel chips, compilation on average takes between 6-15 seconds on first runs. Subsequest runs are much faster (~2 seconds).
+  - On Apple Silicon chips, compilation on average takes between 900-1200ms on first runs. Subsequent runs are much faster (~200ms).
+  - On Intel chips, compilation on average takes between 6-15 seconds on first runs. Subsequent runs are much faster (~2 seconds).
 - Changing the Dart/Flutter version manually is currently not supported - we're working to make this possible in the future.


### PR DESCRIPTION
Fix typos in running-and-saving.mdx